### PR TITLE
Use AREL 'not' method to construct proper query

### DIFF
--- a/lib/devise_deactivatable/model.rb
+++ b/lib/devise_deactivatable/model.rb
@@ -4,7 +4,7 @@ module Devise
       extend ActiveSupport::Concern
       
       included do
-        scope :deactivated, -> { where("'deactivated_at' is not NULL") }
+        scope :deactivated, -> { where.not(deactivated: nil) }
       end
       
       def self.required_fields(klass)


### PR DESCRIPTION
This change fixes the constructed query to include the model's table name which is required for PostgreSQL queries to return expected results.

current behavior:

``` ruby
User.where("'deactivated_at' is not NULL").count
#=> SELECT COUNT(*) FROM "users" WHERE ('deactivated_at' is not NULL)
#=> 64
```

versus the expected behavior:

``` ruby
User.where.not(deactivated_at: nil).count
#=> SELECT COUNT(*) FROM "users" WHERE ("users"."deactivated_at" IS NOT NULL)
#=> 0
```
